### PR TITLE
import Text.Megaparsec.Debug (dbg)

### DIFF
--- a/src/KDL/Parser.hs
+++ b/src/KDL/Parser.hs
@@ -237,7 +237,7 @@ node :: Parser (Maybe Node)
 node = label "Node" $ do
   discard      <- optional comment
   nodeAnn      <- optional typeAnnotation
-  nodeName     <- dbg "name" name
+  nodeName     <- name
   nodeContent  <- catMaybes <$> content
   nodeChildren <- fromMaybe [] <$> optional children
   _            <- many nodespace


### PR DESCRIPTION
In https://github.com/fuzzypixelz/Hustle/commit/eb482d6788e92338289c69a29fb40ff28fd0ae1b, "Remove redundant imports in Parser.hs", `import Text.Megaparsec.Debug` was removed.

However, `dbg` is still used in `KDL.Parser.node`:
https://github.com/fuzzypixelz/Hustle/blob/eb482d6788e92338289c69a29fb40ff28fd0ae1b/src/KDL/Parser.hs#L240

```
❯ cabal repl
Resolving dependencies...
Build profile: -w ghc-9.0.2 -O1
In order, the following will be built (use -v for more details):
 - Hustle-0.1.0.0 (lib) (first run)
Configuring library for Hustle-0.1.0.0..
Preprocessing library for Hustle-0.1.0.0..
GHCi, version 9.0.2: https://www.haskell.org/ghc/  :? for help
[1 of 6] Compiling KDL.Types        ( src/KDL/Types.hs, interpreted )
[2 of 6] Compiling KDL.Internal     ( src/KDL/Internal.hs, interpreted )
[3 of 6] Compiling KDL.Parser       ( src/KDL/Parser.hs, interpreted )

src/KDL/Parser.hs:240:19: error:
    Variable not in scope:
      dbg
        :: t0
           -> Parser Identifier
           -> Text.Megaparsec.Internal.ParsecT
                Data.Void.Void Text Data.Functor.Identity.Identity Identifier
    |
240 |   nodeName     <- dbg "name" name
    |                   ^^^
Failed, two modules loaded.
```

So, this import is still required.